### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,30 +28,30 @@
     "build:js": "uglifyjs public/tabs.js -cmo public/tabs.min.js"
   },
   "dependencies": {
-    "babel": "^5.5.7",
-    "babel-eslint": "^3.1.15",
-    "boom": "^2.7.2",
-    "clean-css": "^3.0.1",
-    "config": "^1.12.0",
-    "crumb": "^4.0.3",
-    "good": "^6.1.0",
-    "good-console": "^5.x.x",
-    "good-file": "^5.0.1",
-    "hapi": "^9.0.0",
-    "hapi-swagger": "^2.0.0",
-    "hoek": "^2.12.0",
-    "inert": "^3.0.1",
-    "jade": "^1.11.0",
-    "joi": "^6.2.0",
-    "piwik-tracker": "*",
-    "request": "^2.57.0",
-    "requestretry": "^1.4.0",
-    "uglify-js": "^2.4.24",
-    "vision": "^3.0.0"
+    "babel": "5.8.23",
+    "babel-eslint": "3.1.30",
+    "boom": "2.9.0",
+    "clean-css": "3.4.5",
+    "config": "1.16.0",
+    "crumb": "4.0.4",
+    "good": "6.4.0",
+    "good-console": "5.1.0",
+    "good-file": "5.1.0",
+    "hapi": "9.3.1",
+    "hapi-swagger": "2.0.0",
+    "hoek": "2.16.3",
+    "inert": "3.0.1",
+    "jade": "1.11.0",
+    "joi": "6.7.1",
+    "piwik-tracker": "0.1.2",
+    "request": "2.64.0",
+    "requestretry": "1.5.0",
+    "uglify-js": "2.4.24",
+    "vision": "3.0.0"
   },
   "devDependencies": {
-    "code": "^1.4.0",
-    "lab": "^5.16.1",
-    "sinon": "^1.14.1"
+    "code": "1.5.0",
+    "lab": "5.18.1",
+    "sinon": "1.17.1"
   }
 }


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>